### PR TITLE
add kiwisec feature on arm64-v8a

### DIFF
--- a/data/apkpackdata.json
+++ b/data/apkpackdata.json
@@ -153,14 +153,24 @@
     "sopath": [
       "lib/armeabi/kdpdata.so",
       "lib/armeabi/libkdp.so",
-      "lib/armeabi/libkwscmm.so"
+      "lib/armeabi/libkwscmm.so",
+	  "lib/arm64-v8a/libkadp.so",
+	  "lib/arm64-v8a/libkiwi_dumper.so",
+	  "lib/arm64-v8a/libkiwicrash.so",
+	  "lib/arm64-v8a/libKwProtectSDK.so",
+	  "lib/arm64-v8a/libkwdataenc.so"
     ],
     "soname": [
       "kdpdata.so",
       "libkdp.so",
       "libkwscmm.so",
       "libkwscr.so",
-      "libkwslinker.so"
+      "libkwslinker.so",
+	  "libkadp.so",
+	  "libkiwi_dumper.so",
+	  "libkiwicrash.so",
+	  "libKwProtectSDK.so",
+	  "libkwdataenc.so"
     ],
     "other": [
       "assets/dex.dat"


### PR DESCRIPTION
增加了针对arm64-v8a平台的kiwi安全的加固特征。
<img width="1423" height="740" alt="kiwisec_feature-1" src="https://github.com/user-attachments/assets/12cf698f-b808-4f20-b992-fc4e16ece368" />

<img width="1642" height="1068" alt="kiwisec_feature-2" src="https://github.com/user-attachments/assets/8a4dc8f1-0b84-483b-9b95-449a4788d67a" />

文件MD5：D2041719F07B8B6CA914E518C52E6717
文件可见：https://www.jxdown.com/soft/40539.html